### PR TITLE
add back btn to details page and scrollToLastOpenCard method

### DIFF
--- a/src/components/BreedDetails.vue
+++ b/src/components/BreedDetails.vue
@@ -28,6 +28,9 @@
         :alt="`Picture of the ${breed.name} dog`"
       />
     </div>
+    <div class="result__go-back">
+      <button class="back-btn" @click="$router.back()">Back</button>
+    </div>
   </div>
 </template>
 
@@ -49,9 +52,13 @@ export default {
 
 <style scoped>
 .result__description {
+  width: 100%;
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
   font-size: 1.4rem;
+  padding: 0 4rem;
+  margin-bottom: 2rem;
 }
 .result__description--title {
   font-weight: 500;
@@ -91,5 +98,33 @@ export default {
 
 ul {
   margin-right: 1rem;
+}
+
+.result__go-back {
+  margin: 0 auto;
+}
+
+.back-btn {
+  font-family: inherit;
+  font-size: 1.2rem;
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
+  cursor: pointer;
+  border: none;
+  border-radius: 0.3rem;
+  padding: 0.8rem 4rem;
+}
+
+.back-btn:hover {
+  transform: scale(1.02) translateY(-0.1rem);
+  box-shadow: 5px 5px 4px 0px #6264728f;
+}
+
+.back-btn:active {
+  transform: scale(1.02) translateY(0.2rem);
+  box-shadow: 3px 3px 2px 0px #6264728f;
+  background-color: var(--background-color2);
+  color: var(--color-primary);
+  font-weight: 700;
 }
 </style>

--- a/src/components/BreedsList.vue
+++ b/src/components/BreedsList.vue
@@ -75,6 +75,7 @@ export default {
       isHidden: true,
       message: "",
       isScrollToTopActive: false,
+      lastBreedState: [],
     };
   },
   methods: {
@@ -172,18 +173,14 @@ export default {
     },
     toggleCard(breed) {
       console.log(breed.isActive, breed.name, this.$route.name);
+      this.lastBreedState.push(breed);
+      console.log(this.lastBreedState);
       breed.isActive = !breed.isActive;
-      this.displayedBreeds.forEach((item) => {
+      this.displayedBreeds.forEach((item, id) => {
         if (item.name !== breed.name) {
           item.isActive = false;
         }
       });
-      if (!breed.isActive) {
-        console.log("push");
-        this.$router.push({
-          name: "breeds",
-        });
-      }
     },
     openDetailsOnRouteParam(breedName) {
       const breedNameParam = breedName.params.breedName;
@@ -205,6 +202,21 @@ export default {
           if (result.length === 0) {
             this.$router.push({
               name: "notFound",
+            });
+          }
+        });
+      }
+    },
+    scrollToLastOpenCard() {
+      if (this.$route.name === "breeds" && this.lastBreedState.length > 0) {
+        this.displayedBreeds.filter((breed, id) => {
+          if (
+            this.lastBreedState[this.lastBreedState.length - 1].name ===
+            breed.name
+          ) {
+            this.$refs.resultListContainer.children[id].scrollIntoView({
+              behavior: "smooth",
+              block: "center",
             });
           }
         });
@@ -260,6 +272,7 @@ export default {
 
     this.openDetailsOnRouteParam(this.$route);
     this.bredNameParamNotFound(this.$route);
+    this.scrollToLastOpenCard();
     if (this.$route.name === "breedName") {
       this.$router.push({
         name: "details",


### PR DESCRIPTION
Na BreedDetails sem dodal `Back `gumb, da gre uporabnik lahko nazaj na vse pasme, en korak nazaj-torej na odprto kartico na `/breeds` route. Dodal sem tudi `scrollToLastOpenCard `metodo, kjer sem dodal `lastBreedState` state, kamor se zapisujejo v array vse klikane kartice. Na podlagi zadnjega state-a, torej zadnje kartice ki je bila odprta, se potem, ko uporabnik klikne `Back `gumb na `BreedDetails `strani, stran scrolla na zadnjo odprto kartico.