### PR TITLE
delete double script tag in index.html which cause the duplicate vue instance error

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <main id="app"></main>
-    <script type="module" src="./node_modules/vue/dist/vue.js"></script>
+
     <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/src/components/BreedCard.vue
+++ b/src/components/BreedCard.vue
@@ -40,12 +40,6 @@ export default {
   methods: {
     toggleDetails() {
       this.$emit("toggle", this.breed, this.id);
-      // if (this.breed.isActive) {
-      //   this.$refs.listItemRef.scrollIntoView({
-      //     behavior: "smooth",
-      //     block: "center",
-      //   });
-      // }
     },
   },
 


### PR DESCRIPTION
V index.html sem imel dva script tag-a, zaradi katerih je prišlo pri kliku na kartico do errorja v consoli 
`vue warn]: $attrs is readonly. `
To pomeni, da sta se dva vue instances loadala istočasno, v vue pa je možen samo single instance. 
Zato sem odstranil ` <script type="module" src="./node_modules/vue/dist/vue.js"></script>`

Bi lahko potestiral če ti deluje sedaj?