### PR TITLE
add only one event for adding up or counting down index for navigation fwd or  back btn

### DIFF
--- a/src/components/BreedsList.vue
+++ b/src/components/BreedsList.vue
@@ -13,8 +13,7 @@
       :lastState="lastBreedState"
       :id="indexClicked"
       :breeds="displayedList"
-      @countdown="scrollToView"
-      @addingUp="scrollToView"
+      @checkingIndex="scrollToView"
     ></the-navigation>
 
     <div class="result__container">

--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -61,7 +61,7 @@ export default {
       this.index--;
 
       this.breeds[this.lastState[this.index]].isActive = true;
-      this.$emit("countdown", this.index);
+      this.$emit("checkingIndex", this.index);
     },
     goForward() {
       this.isForwardButtonClicked = true;
@@ -72,7 +72,7 @@ export default {
       });
       this.index++;
       this.breeds[this.lastState[this.index]].isActive = true;
-      this.$emit("addingUp", this.index);
+      this.$emit("checkingIndex", this.index);
     },
   },
   computed: {

--- a/src/store.js
+++ b/src/store.js
@@ -19,7 +19,6 @@ export const useStore = defineStore("store", {
       if (this.searchQuery) {
         return this.searchList;
       } else {
-        console.log(this.breedsList);
         return this.breedsList;
       }
     },


### PR DESCRIPTION
Namesto dveh različnih eventov (`addingUp `& `countingDown`) imam sedaj samo en event `checkingIndex` pri spremljanju indexa, ob premikanju med odprtimi karticami z `Back `& `Forward `btn navigacijo.